### PR TITLE
优化内存：现在所有的与远端的连接都使用同一个eventLoopGroup

### DIFF
--- a/.idea/artifacts/socks5_netty_jar.xml
+++ b/.idea/artifacts/socks5_netty_jar.xml
@@ -1,0 +1,13 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="socks5-netty:jar">
+    <output-path>$PROJECT_DIR$/classes/artifacts/socks5_netty_jar</output-path>
+    <root id="archive" name="socks5-netty.jar">
+      <element id="module-output" name="socks5-netty" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.10/commons-codec-1.10.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/log4j/log4j/1.2.17/log4j-1.2.17.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/slf4j-log4j12/1.7.21/slf4j-log4j12-1.7.21.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/io/netty/netty-all/4.1.6.Final/netty-all-4.1.6.Final.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar" path-in-jar="/" />
+    </root>
+  </artifact>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="socks5-netty" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="socks5-netty" target="1.5" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,7 +10,7 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="socks5-netty" target="1.5" />
+      <module name="socks5-netty" target="1.9" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/libraries/Maven__com_squareup_okhttp3_okhttp_3_5_0.xml
+++ b/.idea/libraries/Maven__com_squareup_okhttp3_okhttp_3_5_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.squareup.okhttp3:okhttp:3.5.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/squareup/okhttp3/okhttp/3.5.0/okhttp-3.5.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/squareup/okhttp3/okhttp/3.5.0/okhttp-3.5.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/squareup/okhttp3/okhttp/3.5.0/okhttp-3.5.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_squareup_okio_okio_1_11_0.xml
+++ b/.idea/libraries/Maven__com_squareup_okio_okio_1_11_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.squareup.okio:okio:1.11.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/squareup/okio/okio/1.11.0/okio-1.11.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/squareup/okio/okio/1.11.0/okio-1.11.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/squareup/okio/okio/1.11.0/okio-1.11.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__commons_codec_commons_codec_1_10.xml
+++ b/.idea/libraries/Maven__commons_codec_commons_codec_1_10.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: commons-codec:commons-codec:1.10">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.10/commons-codec-1.10.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.10/commons-codec-1.10-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.10/commons-codec-1.10-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__io_netty_netty_all_4_1_6_Final.xml
+++ b/.idea/libraries/Maven__io_netty_netty_all_4_1_6_Final.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: io.netty:netty-all:4.1.6.Final">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/io/netty/netty-all/4.1.6.Final/netty-all-4.1.6.Final.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/io/netty/netty-all/4.1.6.Final/netty-all-4.1.6.Final-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/io/netty/netty-all/4.1.6.Final/netty-all-4.1.6.Final-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__log4j_log4j_1_2_17.xml
+++ b/.idea/libraries/Maven__log4j_log4j_1_2_17.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: log4j:log4j:1.2.17">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/log4j/log4j/1.2.17/log4j-1.2.17.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/log4j/log4j/1.2.17/log4j-1.2.17-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/log4j/log4j/1.2.17/log4j-1.2.17-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_slf4j_slf4j_api_1_7_21.xml
+++ b/.idea/libraries/Maven__org_slf4j_slf4j_api_1_7_21.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.slf4j:slf4j-api:1.7.21">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_slf4j_slf4j_log4j12_1_7_21.xml
+++ b/.idea/libraries/Maven__org_slf4j_slf4j_log4j12_1_7_21.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.slf4j:slf4j-log4j12:1.7.21">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-log4j12/1.7.21/slf4j-log4j12-1.7.21.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-log4j12/1.7.21/slf4j-log4j12-1.7.21-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-log4j12/1.7.21/slf4j-log4j12-1.7.21-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_9" project-jdk-name="9.0" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/socks5-netty.iml" filepath="$PROJECT_DIR$/socks5-netty.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Netty.md
+++ b/Netty.md
@@ -1,0 +1,131 @@
+# netty 学习
+
+## 主要构件
+
+### channel
+
+channel表示一个到实体的开放连接。实体是指硬件设备、文件、网络套接字等。channel是传入和传出数据的载体。（连接——实体——运输数据）
+
+### 回调
+
+我的理解就是
+
+1. A持有B的引用b。
+2. 当A发生了某事件时，调用引用b的callback()方法。
+
+### future
+
+future是另一种操作完成通知应用程序的方式。
+
+jdk中的实现：
+
+```
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        ExecutorService executors=Executors.newFixedThreadPool(20);
+        TaskCallable task=new TaskCallable();
+        Future<String> future=executors.submit(task);
+        System.out.println(future.isDone());
+        String result=future.get();
+        System.out.println(future.isDone());
+        System.out.println(result);
+    }
+```
+
+样例输出
+
+```
+false
+true
+这是callable的运行结果
+```
+
+上面代码的get将会等待线程运行结束（阻塞）。
+
+netty实现了自己ChannelFuture。用于异步操作（大概意思就是非阻塞的使用）。
+
+ChannelFuture可以注册监听器（Listener），当ChannelFuture发生事件时，会调用监听器Listtener对应的方法。ChannelFuture和ChannelFutureListener提供的通知机制不需要程序员手动检查是否操作情况（例如上述的get、isdone等）。
+
+```
+    Channel channel=...;
+    ChannelFuture future=channel.connect("127.0.0.1",25);
+    future.addListener(new ChannelFutureListener(){
+        @Override
+        public void operationComplete(ChannelFuture future){//这里有Channelfuture的引用哦
+            //todo: 操作完成时的操作
+        }
+    });
+```
+
+### 事件和ChannelHandler（通过回调！）
+
+事件：通知状态的更改或者操作的状态
+
+事件分类——入站相关：
+
+- 连接被激活或者连接失活（从socket的角度看都是从远端接受了数据）
+- 数据读取
+- 用户事件
+- 错误事件
+
+出站事件是某个动作的操作结果
+
+- 打开或者关闭到远程节点的连接（从socket角度看都是向远端发送数据）
+- 将数据写到或者冲刷到套接字
+
+每个事件都可以被分发给ChannelHandle中某个用户实现的方法（回调）。
+
+Netty提供了很多开箱即用的ChannelHandler，比如用于Http和Tls的，好像还有用于socks5的。
+
+### channel和EventLoop
+
+在java的NIO中有一个Selector在处理套接字的可读可写事件，并且做相关的处理（派发）。
+
+不同的是，Netty对每一个Channel分配一个EventLoop，用以处理所有事件！包括：
+
+- 注册感兴趣的事件
+- 将事件派发给ChannelHandle
+- 安排进一步的事件
+
+EventLoop本身由一个线程驱动，处理一个Channel的所有IO事件，并且在这个EventLoop生命周期都不会变化。
+
+## 致谢
+
+感谢作者提供了一个很好的学习 netty socks5 的项目。
+
+之前一直想写一个代理，以了解http原理，最终目的是达到大陆到国外的不可描述的目的。作者的项目是很好的sslocal-加密 的项目。
+
+## 问题描述
+
+拿到这个项目，看了很久之后感觉作者写的很完善，没什么好自己动手修改的地方。
+
+然后就看作者的具体实现。用jdk9带的 java misson control 工具查看了一下项目的内存情况。发现当长时间运行，产生多个与远端的连接时，程序占用的内存非常大，而且使用jmc的full gc工具也无法进行垃圾回收。具体情况可以见附图。
+
+看jmc中的线程信息时，发现：出现了350多个类nioEventLoopGroup-350-1的runnable的线程。
+
+结合学习的netty知识判断和对您源码的阅读，判断是在`Socks5CommandRequestHandler.channelRead0()`方法中的`EventLoopGroup bossGroup=new NioEventLoopGroup();`语句导致的。这句话导致——每次需要代理新建到远程服务器的连接时，都创建了一个NioEventLoopGroup。而且经过上面fullGC的测试，这些NioEventLoopGroup还不能被回收。
+
+## 问题解决
+
+netty实战告诉我，服务器端有两个NioEventLoopGroup，客户端有一个NioEventLoopGroup。
+
+所以我设想，只使用一个NioEventLoopGroup固定的处理所有对远程的channel。
+
+我做出了如下修改
+在`Socks5CommandRequestHandler`中增加：
+
+```
+    private EventLoopGroup bossGroup;
+    public Socks5CommandRequestHandler(ProxyServer proxyServer) {
+        bossGroup=proxyServer.getBossGroup();
+    }
+```
+
+即在ProxyServer中创建一个单独的NioEventLoopGroup，在Socks5CommandRequestHandler，导入这个NioEventLoopGroup,用以管理与远程的连接。
+
+## 效果
+
+在JMC的线程页面中显示只有3个NioEventLoopGroup（编号分别位2、3、4）。当执行full gc时，内存占用降低到13.8M。这个数据非常稳定，13.8M。
+
+## 谢谢
+
+这是第一次在github上提交issue。也是第一次利用自己的知识解决java内存相关的问题。感觉很宝贵。

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,11 @@
 	<artifactId>socks5-netty</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.9</maven.compiler.source>
+		<maven.compiler.target>1.9</maven.compiler.target>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>io.netty</groupId>
@@ -31,75 +36,39 @@
 
 	<build>
 		<plugins>
+
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>appassembler-maven-plugin</artifactId>
-				<version>1.10</version>
-				<executions>
-					<execution>
-						<!--执行脚本的id -->
-						<id>generate-jsw-scripts</id>
-						<!--在maven的package阶段执行 -->
-						<phase>package</phase>
-						<goals>
-							<goal>generate-daemons</goal>
-						</goals>
-					</execution>
-				</executions>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.6</version>
 				<configuration>
-					<!--打包后生成的目录位置 -->
-					<target>${project.build.directory}/assembler</target>
-					<!--是否将配置文件包含到classpath -->
-					<includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
-					<!--为系统配置文件指定一个目录 -->
-					<configurationDirectory>conf</configurationDirectory>
-					<!--源代码中对应的系统配置文件的位置 -->
-					<configurationSourceDirectory>src/main/resources</configurationSourceDirectory>
-					<!--是否拷贝源代码中配置文件中的目录 -->
-					<copyConfigurationDirectory>true</copyConfigurationDirectory>
-					<!--依赖的lib包的目录格式，flat表示不分目录平铺到lib目录下 -->
-					<repositoryLayout>flat</repositoryLayout>
-					<!--依赖的lib包的目录名称 -->
-					<repositoryName>lib</repositoryName>
-					<daemons>
-						<daemon>
-							<id>proxy</id>
-							<!--系统的入口main函数类 -->
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<!--<classpathPrefix>lib/</classpathPrefix>-->
 							<mainClass>com.geccocrawler.socks5.ProxyServer</mainClass>
-							<jvmSettings>
-								<initialMemorySize>256M</initialMemorySize>
-								<maxMemorySize>512M</maxMemorySize>
-								<extraArguments>
-									<extraArgument>-Djava.net.preferIPv4Stack=true</extraArgument>
-								</extraArguments>
-							</jvmSettings>
-							<generatorConfigurations>
-								<generatorConfiguration>
-									<generator>jsw</generator>
-									<includes>
-										<include>linux-x86-64</include>
-										<includ>windows-x86-64</includ>
-									</includes>
-									<configuration>
-										<property>
-											<!--手动添加一个系统启动时依赖的第一个classpath，这里通常写为配置文件的目录名，如果不配置，配置文件无法找到 -->
-											<name>configuration.directory.in.classpath.first</name>
-											<value>conf</value>
-										</property>
-										<property>
-											<name>wrapper.logfile</name>
-											<value>log/app.log</value>
-										</property>
-									</configuration>
-								</generatorConfiguration>
-							</generatorConfigurations>
-							<platforms>
-								<platform>jsw</platform>
-							</platforms>
-						</daemon>
-					</daemons>
+						</manifest>
+					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<id>copy-dependencies</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/lib</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 </project>

--- a/socks5-netty.iml
+++ b/socks5-netty.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_9">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/socks5-netty.iml
+++ b/socks5-netty.iml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: io.netty:netty-all:4.1.6.Final" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-log4j12:1.7.21" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.21" level="project" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.squareup.okhttp3:okhttp:3.5.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.squareup.okio:okio:1.11.0" level="project" />
+  </component>
+</module>

--- a/src/main/java/com/geccocrawler/socks5/ProxyServer.java
+++ b/src/main/java/com/geccocrawler/socks5/ProxyServer.java
@@ -33,7 +33,13 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 
 public class ProxyServer {
-	
+
+	private EventLoopGroup bossGroup=new NioEventLoopGroup();
+
+	public EventLoopGroup getBossGroup() {
+		return bossGroup;
+	}
+
 	private static final Logger logger = LoggerFactory.getLogger(ProxyServer.class);
 	
 	private int port;
@@ -146,7 +152,7 @@ public class ProxyServer {
 					//socks connection
 					ch.pipeline().addLast(new Socks5CommandRequestDecoder());
 					//Socks connection
-					ch.pipeline().addLast(new Socks5CommandRequestHandler());
+					ch.pipeline().addLast(new Socks5CommandRequestHandler(ProxyServer.this.getBossGroup()));
 				}
 			});
 			

--- a/src/main/java/com/geccocrawler/socks5/handler/ss5/Socks5CommandRequestHandler.java
+++ b/src/main/java/com/geccocrawler/socks5/handler/ss5/Socks5CommandRequestHandler.java
@@ -23,15 +23,20 @@ import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
 import io.netty.handler.codec.socksx.v5.Socks5CommandType;
 
 public class Socks5CommandRequestHandler extends SimpleChannelInboundHandler<DefaultSocks5CommandRequest>{
+	EventLoopGroup bossGroup;
 	
 	private static final Logger logger = LoggerFactory.getLogger(Socks5CommandRequestHandler.class);
-	
+
+	public Socks5CommandRequestHandler(EventLoopGroup bossGroup) {
+		this.bossGroup=bossGroup;
+	}
+
 	@Override
 	protected void channelRead0(final ChannelHandlerContext clientChannelContext, DefaultSocks5CommandRequest msg) throws Exception {
 		logger.debug("目标服务器  : " + msg.type() + "," + msg.dstAddr() + "," + msg.dstPort());
 		if(msg.type().equals(Socks5CommandType.CONNECT)) {
 			logger.trace("准备连接目标服务器");
-			EventLoopGroup bossGroup = new NioEventLoopGroup();
+
 			Bootstrap bootstrap = new Bootstrap();
 			bootstrap.group(bossGroup)
 			.channel(NioSocketChannel.class)

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,2 +1,2 @@
-port=11080
-auth=true
+port=1081
+auth=false


### PR DESCRIPTION
## 致谢

感谢作者提供了一个很好的学习 netty socks5 的项目。

之前一直想写一个代理，以了解http原理，最终目的是达到大陆到国外的不可描述的目的。作者的项目是很好的sslocal-加密 的项目。

## 问题描述

拿到这个项目，看了很久之后感觉作者写的很完善，没什么好自己动手修改的地方。

然后就看作者的具体实现。用jdk9带的 java misson control 工具查看了一下项目的内存情况。发现当长时间运行，产生多个与远端的连接时，程序占用的内存非常大，而且使用jmc的full gc工具也无法进行垃圾回收。具体情况可以见附图。
![default](https://user-images.githubusercontent.com/21768987/38613714-5a0eba2a-3dbd-11e8-9f10-656183a46c4f.PNG)
![default](https://user-images.githubusercontent.com/21768987/38613715-5a6afede-3dbd-11e8-90ee-60d993050838.PNG)


看jmc中的线程信息时，发现：出现了350多个类nioEventLoopGroup-350-1的runnable的线程。

结合学习的netty知识判断和对您源码的阅读，判断是在`Socks5CommandRequestHandler.channelRead0()`方法中的`EventLoopGroup bossGroup=new NioEventLoopGroup();`语句导致的。这句话导致——每次需要代理新建到远程服务器的连接时，都创建了一个NioEventLoopGroup。而且经过上面fullGC的测试，这些NioEventLoopGroup还不能被回收。

## 问题解决

netty实战告诉我，服务器端有两个NioEventLoopGroup，客户端有一个NioEventLoopGroup。

所以我设想，只使用一个NioEventLoopGroup固定的处理所有对远程的channel。

我做出了如下修改
在`Socks5CommandRequestHandler`中增加：

```java
    private EventLoopGroup bossGroup;
    public Socks5CommandRequestHandler(ProxyServer proxyServer) {
        bossGroup=proxyServer.getBossGroup();
    }
```

即在ProxyServer中创建一个单独的NioEventLoopGroup，在Socks5CommandRequestHandler，导入这个NioEventLoopGroup,用以管理与远程的连接。

## 效果

在JMC的线程页面中显示只有3个NioEventLoopGroup（编号分别位2、3、4）。当执行full gc时，内存占用降低到13.8M。这个数据非常稳定，13.8M。
![default](https://user-images.githubusercontent.com/21768987/38613727-61df9c4c-3dbd-11e8-8dcf-e10bc88e0691.PNG)
![default](https://user-images.githubusercontent.com/21768987/38613728-623b1270-3dbd-11e8-8e35-08ef9e647e98.PNG)


## 谢谢

这是第一次在github上提交issue。也是第一次利用自己的知识解决java内存相关的问题。感觉很宝贵。





